### PR TITLE
Removed WebUtility.UrlDecode

### DIFF
--- a/src/Cloud5mins.ShortenerTools.Functions/Functions/UrlRedirect.cs
+++ b/src/Cloud5mins.ShortenerTools.Functions/Functions/UrlRedirect.cs
@@ -44,7 +44,7 @@ namespace Cloud5mins.ShortenerTools.Functions
                     newUrl.Clicks++;
                     await stgHelper.SaveClickStatsEntity(new ClickStatsEntity(newUrl.RowKey));
                     await stgHelper.SaveShortUrlEntity(newUrl);
-                    redirectUrl = WebUtility.UrlDecode(newUrl.ActiveUrl);
+                    redirectUrl = newUrl.ActiveUrl;
                 }
             }
             else


### PR DESCRIPTION
The use of 'WebUtility.UrlDecode' is causing the URL to malfunction by altering its content. When the URL contains characters such as '%2B' and '%3D', their values are modified. As an instance, when the URL has the string '2BElZOY0h%2BYs%3D', it is transformed into '2BElZOY0h+Ys=', which is incorrect.

If a user attempts to create a URL with a SAS token in Azure blog storage, they may encounter URLs of this nature.