### PR TITLE
Using ReadToEndAsync to replace ReadToEnd

### DIFF
--- a/src/Cloud5mins.ShortenerTools.Functions/Functions/UrlArchive.cs
+++ b/src/Cloud5mins.ShortenerTools.Functions/Functions/UrlArchive.cs
@@ -70,7 +70,7 @@ namespace Cloud5mins.ShortenerTools.Functions
 
                 using (var reader = new StreamReader(req.Body))
                 {
-                    var body = reader.ReadToEnd();
+                    var body = await reader.ReadToEndAsync();
                     input = JsonSerializer.Deserialize<ShortUrlEntity>(body, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
                     if (input == null)
                     {

--- a/src/Cloud5mins.ShortenerTools.Functions/Functions/UrlClickStatsByDay.cs
+++ b/src/Cloud5mins.ShortenerTools.Functions/Functions/UrlClickStatsByDay.cs
@@ -70,7 +70,7 @@ namespace Cloud5mins.ShortenerTools.Functions
             {
                 using (var reader = new StreamReader(req.Body))
                 {
-                    var strBody = reader.ReadToEnd();
+                    var strBody = await reader.ReadToEndAsync();
                     input = JsonSerializer.Deserialize<UrlClickStatsRequest>(strBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
                     if (input == null)
                     {

--- a/src/Cloud5mins.ShortenerTools.Functions/Functions/UrlCreate.cs
+++ b/src/Cloud5mins.ShortenerTools.Functions/Functions/UrlCreate.cs
@@ -67,7 +67,7 @@ namespace Cloud5mins.ShortenerTools.Functions
 
                 using (var reader = new StreamReader(req.Body))
                 {
-                    var strBody = reader.ReadToEnd();
+                    var strBody = await reader.ReadToEndAsync();
                     input = JsonSerializer.Deserialize<ShortRequest>(strBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
                     if (input == null)
                     {

--- a/src/Cloud5mins.ShortenerTools.Functions/Functions/UrlUpdate.cs
+++ b/src/Cloud5mins.ShortenerTools.Functions/Functions/UrlUpdate.cs
@@ -76,7 +76,7 @@ namespace Cloud5mins.ShortenerTools.Functions
 
                 using (var reader = new StreamReader(req.Body))
                 {
-                    var strBody = reader.ReadToEnd();
+                    var strBody = await reader.ReadToEndAsync();
                     input = JsonSerializer.Deserialize<ShortUrlEntity>(strBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
                     if (input == null)
                     {


### PR DESCRIPTION
Based on [Avoid using synchronous Read/Write overloads on HttpRequest.Body and HttpResponse.Body](https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AspNetCoreGuidance.md#avoid-using-synchronous-readwrite-overloads-on-httprequestbody-and-httpresponsebody) and many samples of azure function, such as 

https://github.com/azure-samples/azure-sql-binding-func-dotnet-todo/blob/main/PostToDo.cs#L27

and

https://github.com/azure-samples/media-services-v3-dotnet-core-functions-integration/blob/main/Functions/CreateEmptyAsset.cs#L86

Using `ReadToEndAsync` to replace `ReadToEnd` may be better here.