### PR TITLE
Remove obsolete option IgnoreScriptIsolation

### DIFF
--- a/src/Cloud5mins.ShortenerTools.TinyBlazorAdmin/Program.cs
+++ b/src/Cloud5mins.ShortenerTools.TinyBlazorAdmin/Program.cs
@@ -20,6 +20,6 @@ builder.Services
 // regiser fusion blazor service
 // Community Licence for your personal use ONLY. Thank you Syncfusion for this generous offer.
 Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense("NzYyMzI1QDMyMzAyZTMxMmUzMFY0cEZ3MVozdkwvekVhek8xTWdPMkg2NlhvdVFNR1lvZHdhQWJWUlNjZW89"); 
-builder.Services.AddSyncfusionBlazor(options => { options.IgnoreScriptIsolation = true; });
+builder.Services.AddSyncfusionBlazor();
 
 await builder.Build().RunAsync();


### PR DESCRIPTION
`IgnoreScriptIsolation `  this property is obsolete.

Docs: https://blazor.syncfusion.com/documentation/chip/getting-started

![image](https://user-images.githubusercontent.com/13200155/224136949-e9280495-e05e-4a8d-a423-86a21aa66354.png)
