### PR TITLE
Allow redirection if non vanity provided

### DIFF
--- a/src/Cloud5mins.ShortenerTools.Core/Domain/ShortenerSettings.cs
+++ b/src/Cloud5mins.ShortenerTools.Core/Domain/ShortenerSettings.cs
@@ -3,6 +3,7 @@ namespace Cloud5mins.ShortenerTools.Core.Domain
     public class ShortenerSettings
     {
         public string DefaultRedirectUrl { get; set; }
+        public string RootRedirectUrl { get; set; }
         public string CustomDomain { get; set; }
         public string DataStorage { get; set; }
     }

--- a/src/Cloud5mins.ShortenerTools.Functions/Functions/UrlRedirectRoot.cs
+++ b/src/Cloud5mins.ShortenerTools.Functions/Functions/UrlRedirectRoot.cs
@@ -1,0 +1,37 @@
+using Cloud5mins.ShortenerTools.Core.Domain;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using System.Linq;
+using System.Net;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Cloud5mins.ShortenerTools.Functions
+{
+    public class UrlRedirectRoot
+    {
+        private readonly ILogger _logger;
+        private readonly ShortenerSettings _settings;
+
+        public UrlRedirectRoot(ILoggerFactory loggerFactory, ShortenerSettings settings)
+        {
+            _logger = loggerFactory.CreateLogger<UrlRedirectRoot>();
+            _settings = settings;
+        }
+
+        [Function("UrlRedirectRoot")]
+        public async Task<HttpResponseData> Run(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "/")]
+            HttpRequestData req,
+            ExecutionContext context)
+        {
+            string redirectUrl = _settings.RootRedirectUrl ?? _settings.DefaultRedirectUrl ?? "https://azure.com";
+            var res = req.CreateResponse(HttpStatusCode.Redirect);
+            res.Headers.Add("Location", redirectUrl);
+            return res;
+
+        }
+    }
+}

--- a/src/deployment/azureDeploy.json
+++ b/src/deployment/azureDeploy.json
@@ -23,6 +23,13 @@
                 "description": "Default URL used when key passed by the user is not found."
             }
         },
+        "rootRedirectUrl": {
+            "defaultValue": "https://azure.com",
+            "type": "string",
+            "metadata": {
+                "description": "URL used someone access the root (/)."
+            }
+        },
         "GitHubURL": {
             "type": "string",
             "defaultValue": "https://github.com/microsoft/AzUrlShortener.git",
@@ -117,6 +124,14 @@
                         {
                             "name": "defaultRedirectUrl",
                             "value": "[parameters('defaultRedirectUrl')]"
+                        },
+                        {
+                            "name": "rootRedirectUrl",
+                            "value": "[parameters('rootRedirectUrl')]"
+                        },
+                        {
+                            "name": "AzureWebJobsDisableHomepage",
+                            "value": "true"
                         }
                     ]
                 },


### PR DESCRIPTION
Fixes #464 by redirecting root to configured `rootDirectUrl` or `defaultRedirectUrl` (configured as App Settings) or `azure.com` (hard coded). You need to configure `AzureWebJobsDisableHomepage=true` to disable the homepage shown at default. This is added to the ARM template. 