### PR TITLE
fix: Fix for old saved urls

### DIFF
--- a/src/Cloud5mins.ShortenerTools.Core/Domain/ShortUrlEntity.cs
+++ b/src/Cloud5mins.ShortenerTools.Core/Domain/ShortUrlEntity.cs
@@ -1,7 +1,4 @@
 using Microsoft.Azure.Cosmos.Table;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text.Json;
 
 namespace Cloud5mins.ShortenerTools.Core.Domain
@@ -46,7 +43,7 @@ namespace Cloud5mins.ShortenerTools.Core.Domain
                     }
                     else
                     {
-                        _schedules = JsonSerializer.Deserialize<Schedule[]>(SchedulesPropertyRaw).ToList<Schedule>();
+                        _schedules = JsonSerializer.Deserialize<Schedule[]>(SchedulesPropertyRaw)?.ToList<Schedule>() ?? new List<Schedule>();
                     }
                 }
                 return _schedules;
@@ -83,7 +80,7 @@ namespace Cloud5mins.ShortenerTools.Core.Domain
             Clicks = 0;
             IsArchived = false;
 
-            if(schedules?.Length>0)
+            if (schedules?.Length > 0)
             {
                 Schedules = schedules.ToList<Schedule>();
                 SchedulesPropertyRaw = JsonSerializer.Serialize<List<Schedule>>(Schedules);


### PR DESCRIPTION
I'm using the previous version of the shortener in production and seems the redirect logic does not account for previously saved URLs. This fix allows previously saved URLs to function correctly with v3 of the shortener. 