### PR TITLE
Replacing SyncFusion charts by Blazorbootstrap

### DIFF
--- a/src/Cloud5mins.ShortenerTools.TinyBlazorAdmin/Cloud5mins.ShortenerTools.TinyBlazorAdmin.csproj
+++ b/src/Cloud5mins.ShortenerTools.TinyBlazorAdmin/Cloud5mins.ShortenerTools.TinyBlazorAdmin.csproj
@@ -9,8 +9,7 @@
   <ItemGroup>
 	<PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.*-* " />
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.*-* " />
-    <PackageReference Include="Syncfusion.Blazor.Charts" Version="28.2.6" />
-    <PackageReference Include="Syncfusion.Blazor.Spinner" Version="28.2.6" />
+    <PackageReference Include="Blazor.Bootstrap" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cloud5mins.ShortenerTools.TinyBlazorAdmin/Components/App.razor
+++ b/src/Cloud5mins.ShortenerTools.TinyBlazorAdmin/Components/App.razor
@@ -8,7 +8,9 @@
     <link rel="stylesheet" href="app.css" />
     <link rel="stylesheet" href="Cloud5mins.ShortenerTools.TinyBlazorAdmin.styles.css" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
-    <script src="_content/Syncfusion.Blazor.Core/scripts/syncfusion-blazor.min.js" type="text/javascript"></script>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet" />
+    <link href="_content/Blazor.Bootstrap/blazor.bootstrap.css" rel="stylesheet" />
     <HeadOutlet />
 </head>
 
@@ -19,6 +21,15 @@
     <script src="_content/Microsoft.FluentUI.AspNetCore.Components/js/loading-theme.js" type="text/javascript"></script>
     <loading-theme storage-name="theme"></loading-theme>
 </body>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+<!-- Add chart.js reference if chart components are used in your application. -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.0.1/chart.umd.js" integrity="sha512-gQhCDsnnnUfaRzD8k1L5llCCV6O9HN09zClIzzeJ8OJ9MpGmIlCxm+pdCkqTwqJ4JcjbojFr79rl2F1mzcoLMQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<!-- Add chartjs-plugin-datalabels.min.js reference if chart components with data label feature is used in your application. -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/chartjs-plugin-datalabels/2.2.0/chartjs-plugin-datalabels.min.js" integrity="sha512-JPcRR8yFa8mmCsfrw4TNte1ZvF1e3+1SdGMslZvmrzDYxS69J7J49vkFL8u6u8PlPJK+H3voElBtUCzaXj+6ig==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<!-- Add sortable.js reference if SortableList component is used in your application. -->
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script>
+<script src="_content/Blazor.Bootstrap/blazor.bootstrap.js"></script>
 
 <script>
     window.clipboardCopy = {

--- a/src/Cloud5mins.ShortenerTools.TinyBlazorAdmin/Components/App.razor
+++ b/src/Cloud5mins.ShortenerTools.TinyBlazorAdmin/Components/App.razor
@@ -5,31 +5,26 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <base href="/" />
-    <link rel="stylesheet" href="app.css" />
-    <link rel="stylesheet" href="Cloud5mins.ShortenerTools.TinyBlazorAdmin.styles.css" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet" />
     <link href="_content/Blazor.Bootstrap/blazor.bootstrap.css" rel="stylesheet" />
+    <link rel="stylesheet" href="app.css" />
+    <link rel="stylesheet" href="Cloud5mins.ShortenerTools.TinyBlazorAdmin.styles.css" />
     <HeadOutlet />
 </head>
 
 <body>
     <Routes />
     <script src="_framework/blazor.web.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.0.1/chart.umd.js" integrity="sha512-gQhCDsnnnUfaRzD8k1L5llCCV6O9HN09zClIzzeJ8OJ9MpGmIlCxm+pdCkqTwqJ4JcjbojFr79rl2F1mzcoLMQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/chartjs-plugin-datalabels/2.2.0/chartjs-plugin-datalabels.min.js" integrity="sha512-JPcRR8yFa8mmCsfrw4TNte1ZvF1e3+1SdGMslZvmrzDYxS69J7J49vkFL8u6u8PlPJK+H3voElBtUCzaXj+6ig==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="_content/Blazor.Bootstrap/blazor.bootstrap.js"></script>
     <!-- Set the default theme -->
     <script src="_content/Microsoft.FluentUI.AspNetCore.Components/js/loading-theme.js" type="text/javascript"></script>
     <loading-theme storage-name="theme"></loading-theme>
 </body>
-
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
-<!-- Add chart.js reference if chart components are used in your application. -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.0.1/chart.umd.js" integrity="sha512-gQhCDsnnnUfaRzD8k1L5llCCV6O9HN09zClIzzeJ8OJ9MpGmIlCxm+pdCkqTwqJ4JcjbojFr79rl2F1mzcoLMQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-<!-- Add chartjs-plugin-datalabels.min.js reference if chart components with data label feature is used in your application. -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/chartjs-plugin-datalabels/2.2.0/chartjs-plugin-datalabels.min.js" integrity="sha512-JPcRR8yFa8mmCsfrw4TNte1ZvF1e3+1SdGMslZvmrzDYxS69J7J49vkFL8u6u8PlPJK+H3voElBtUCzaXj+6ig==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-<!-- Add sortable.js reference if SortableList component is used in your application. -->
-<script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script>
-<script src="_content/Blazor.Bootstrap/blazor.bootstrap.js"></script>
 
 <script>
     window.clipboardCopy = {

--- a/src/Cloud5mins.ShortenerTools.TinyBlazorAdmin/Components/Pages/Home.razor
+++ b/src/Cloud5mins.ShortenerTools.TinyBlazorAdmin/Components/Pages/Home.razor
@@ -11,7 +11,7 @@
     <div>
     <p>This is the frontend of a solution using <a href="https://github.com/FBoucher/AzUrlShortener" target="_blank">AzUrlShortener</a> both projects are available on GitHub.</p>
     
-    <p>This site is build using <a href="http://blazor.net/" target="_blank">.Net Blazor Web Assembly</a> and some Blazor components from <a href="https://blazor.syncfusion.com/" target="_blank">Syncfusion</a> (thank you for the Community licence)</p>
+    <p>This site is build using <a href="http://blazor.net/" target="_blank">.Net Blazor</a> and some Blazor components from <a href="https://www.fluentui-blazor.net/" target="_blank">FluentUI Blazor</a> and the chart are from <a href="https://demos.blazorbootstrap.com/" target="_blank">BlazorBootstrap</a></p>
 
     <p>If you want to learn more about Tiny Blazor Admin please refer to the <a href="https://github.com/FBoucher/TinyBlazorAdmin" target="_blank">documentation</a>.</p>
     </div>

--- a/src/Cloud5mins.ShortenerTools.TinyBlazorAdmin/Components/Pages/Statistics.razor
+++ b/src/Cloud5mins.ShortenerTools.TinyBlazorAdmin/Components/Pages/Statistics.razor
@@ -1,11 +1,9 @@
 @page "/statistics"
 @page "/statistics/{vanity}"
 
+@using BlazorBootstrap
 @using Cloud5mins.ShortenerTools.Core.Messages;
 @using Cloud5mins.ShortenerTools.Core.Domain
-@using Syncfusion.Blazor
-@using Syncfusion.Blazor.Charts
-@using Syncfusion.Blazor.Spinner
 @using Microsoft.AspNetCore.Authorization
 @using System.Collections.ObjectModel
 @using System.Text.Json
@@ -20,37 +18,7 @@
 <a href="/UrlManager/"> &lt;&lt; Back</a>
 
 <div id="stats" >
-@if(clicksHistory != null){
-<SfChart Title="Click Stats" Width="900px" >
-    <ChartEvents/>
-    <ChartArea><ChartAreaBorder Width="1"></ChartAreaBorder></ChartArea>
-    <ChartPrimaryXAxis  ValueType="Syncfusion.Blazor.Charts.ValueType.DateTime"  
-                        LabelFormat="y/M/d" 
-                        EdgeLabelPlacement="EdgeLabelPlacement.Shift" RangePadding="ChartRangePadding.Auto">
-        <ChartAxisMajorGridLines Width="1"></ChartAxisMajorGridLines>
-    </ChartPrimaryXAxis>
-
-    <ChartPrimaryYAxis  LabelFormat="{value}" >
-            <ChartAxisLineStyle Width="1"></ChartAxisLineStyle>
-            <ChartAxisMajorTickLines Width="1"></ChartAxisMajorTickLines>
-    </ChartPrimaryYAxis>
-    <ChartTooltipSettings Enable="true"></ChartTooltipSettings>
-    
-    <ChartSeriesCollection>
-        <ChartSeries    DataSource="@clicksHistory" 
-                        Name="Click(s) by Day"
-                        XName="DateClicked" 
-                        YName="Count" 
-                        Type="ChartSeriesType.Line">
-            <ChartMarker Visible="true" ></ChartMarker>
-        </ChartSeries>
-    </ChartSeriesCollection>
-    
-</SfChart>
-}
-else{
-    <SfSpinner Size="40" Label="Counting all those clicks..." Type="SpinnerType.Material" Visible="@isLoading"></SfSpinner>
-}
+    <BarChart @ref="barChart" Width="800" Height="400" />
 </div>
 <div>
     <h3>@dayCount</h3>
@@ -62,22 +30,33 @@ else{
 #nullable enable
     public string? vanity { get; set; }
 #nullable disable
-
-    private bool isLoading { get; set; } = true;
     private string subTitle = "";
-
-    private ObservableCollection<ClickDate>? clicksHistory = null;
+    private ChartData chartData = new ChartData();
     private readonly Random _random = new Random(); 
     private string dayCount = string.Empty;
+    private BarChart barChart = default!;
 
-    private async Task<ObservableCollection<ClickDate>> UpdateUIList()
+    private async Task<ChartData> UpdateUIList()
     {
         subTitle = (!String.IsNullOrEmpty(vanity))? $"Clicks for: {vanity}": "All clicks";
         try{
 
             var response = await urlManager.UrlClickStatsByDay( new UrlClickStatsRequest(vanity));
-            if(response != null){            
-                return new ObservableCollection<ClickDate>(response.Items);
+            if(response != null){    
+                var data = new ChartData(){
+                    Labels =  GetDateRange(response.Items.Min(x => x.DateClicked)),
+                    //Labels = response.Items.Select(x => x.DateClicked.ToString("yyyy-MM-dd")).ToList(),
+                    Datasets = new List<IChartDataset>()
+                    {
+                        new BarChartDataset
+                        {
+                            Label = "Click(s) by Day",
+                            Data = response.Items.Select(x => (double?)x.Count).ToList(),
+                            BackgroundColor = new List<string>{ "rgb(88, 80, 141)" },
+                        }
+                    }
+                };
+                return data;
             }
         }
         catch (System.Exception ex)
@@ -85,29 +64,54 @@ else{
             Console.WriteLine(ex.ToString()); 
         }
         return null;
+
+    }
+    protected override async Task OnInitializedAsync()
+    {
+
     }
 
 
-    @* protected override void OnInitialized()
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        clicksHistory = UpdateUIList().Result;
-        
-        if(clicksHistory != null){
-            dayCount = "Day(s): " + clicksHistory.Count.ToString();
+        if (firstRender)
+        {
+            await RenderChartAsync();
         }
-        this.isLoading = false;
-        StateHasChanged();
+        await base.OnAfterRenderAsync(firstRender);
+    }
 
-    } *@
-    protected override async Task OnInitializedAsync()
+    private async Task RenderChartAsync()
     {
-        clicksHistory = await UpdateUIList();
+        chartData = await UpdateUIList();
         
-        if(clicksHistory != null){
-            dayCount = "Day(s): " + clicksHistory.Count.ToString();
+        if(chartData.Datasets != null){
+            dayCount = "Day(s): " + chartData.Datasets.Count.ToString();
         }
-        this.isLoading = false;
-        StateHasChanged();
 
+        var options = new BarChartOptions();
+        options.Interaction.Mode = InteractionMode.Index;
+
+        options.Plugins.Title!.Text = "Click Stats";
+        options.Plugins.Title.Display = true;
+        options.Plugins.Title.Font = new ChartFont { Size = 20 };
+
+        options.Responsive = true;
+
+        options.Scales.X!.Title = new ChartAxesTitle { Text = "Date Clicked", Display = true };
+        options.Scales.Y!.Title = new ChartAxesTitle { Text = "Count", Display = true };
+
+        await barChart.InitializeAsync(chartData, options);
+    }
+
+    private List<string> GetDateRange(DateTime startDate)
+    {
+        DateTime endDate = DateTime.Now;
+        List<string> dateRange = new List<string>();
+        for (DateTime date = startDate; date <= endDate; date = date.AddDays(1))
+        {
+            dateRange.Add(date.ToString("yyyy-MM-dd"));
+        }
+        return dateRange;
     }
 }

--- a/src/Cloud5mins.ShortenerTools.TinyBlazorAdmin/Components/Pages/Statistics.razor
+++ b/src/Cloud5mins.ShortenerTools.TinyBlazorAdmin/Components/Pages/Statistics.razor
@@ -45,14 +45,13 @@
             if(response != null){    
                 var data = new ChartData(){
                     Labels =  GetDateRange(response.Items.Min(x => x.DateClicked)),
-                    //Labels = response.Items.Select(x => x.DateClicked.ToString("yyyy-MM-dd")).ToList(),
                     Datasets = new List<IChartDataset>()
                     {
                         new BarChartDataset
                         {
                             Label = "Click(s) by Day",
                             Data = response.Items.Select(x => (double?)x.Count).ToList(),
-                            BackgroundColor = new List<string>{ "rgb(88, 80, 141)" },
+                            BackgroundColor = new List<string>{ "rgb(150, 91, 227)" },
                         }
                     }
                 };
@@ -64,14 +63,7 @@
             Console.WriteLine(ex.ToString()); 
         }
         return null;
-
     }
-    protected override async Task OnInitializedAsync()
-    {
-
-    }
-
-
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)

--- a/src/Cloud5mins.ShortenerTools.TinyBlazorAdmin/Program.cs
+++ b/src/Cloud5mins.ShortenerTools.TinyBlazorAdmin/Program.cs
@@ -2,7 +2,6 @@ using Microsoft.FluentUI.AspNetCore.Components;
 using Cloud5mins.ShortenerTools.TinyBlazorAdmin.Components;
 using Cloud5mins.ShortenerTools.TinyBlazorAdmin;
 using Microsoft.FluentUI.AspNetCore.Components.Components.Tooltip;
-using Syncfusion.Blazor;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -19,10 +18,8 @@ builder.Services.AddRazorComponents()
 builder.Services.AddFluentUIComponents();
 builder.Services.AddScoped<ITooltipService, TooltipService>();
 
-// regiser fusion blazor service
-// Community Licence for your personal use ONLY. Thank you Syncfusion for this generous offer.
-Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense("Ngo9BigBOggjHTQxAR8/V1NHaF5cWWdCf1FpRmJGdld5fUVHYVZUTXxaS00DNHVRdkdmWX1fdHVQR2RYVUNxW0c="); 
-builder.Services.AddSyncfusionBlazor();
+//Blazor Bootstrap service
+builder.Services.AddBlazorBootstrap();
 
 var app = builder.Build();
 app.MapDefaultEndpoints();


### PR DESCRIPTION
In the admin website Removing the SyncFusion components references and replacing them with Blazor Bootstrap components.