### PR TITLE
Checks if URL is archived before redirecting.

### DIFF
--- a/src/Core/Service/UrlServices.cs
+++ b/src/Core/Service/UrlServices.cs
@@ -37,6 +37,13 @@ public class UrlServices
 				if (newUrl != null)
 				{
 					_logger.LogInformation($"Found it: {newUrl.Url}");
+
+					if (newUrl.IsArchived ?? false)
+					{
+						_logger.LogInformation($"This URL is archived.");
+						return redirectUrl;
+					}
+					
 					newUrl.Clicks++;
 					await _stgHelper.SaveClickStatsEntity(new ClickStatsEntity(newUrl.RowKey));
 					await _stgHelper.SaveShortUrlEntity(newUrl);


### PR DESCRIPTION
Adds a check to determine if a shortened URL is archived. If the URL is archived, it returns immediately, preventing further processing and redirection.
Fixing #510 