### PR TITLE
Adds CreatedDate to ShortUrlEntity

### DIFF
--- a/src/Core/Domain/ShortUrlEntity.cs
+++ b/src/Core/Domain/ShortUrlEntity.cs
@@ -63,6 +63,7 @@ namespace Cloud5mins.ShortenerTools.Core.Domain
         public string RowKey { get; set; }
         public DateTimeOffset? Timestamp { get; set; }
         public ETag ETag { get; set; }
+        public string CreatedDate { get; set; }
 
 
         public ShortUrlEntity() { }
@@ -90,6 +91,7 @@ namespace Cloud5mins.ShortenerTools.Core.Domain
             Title = title;
             Clicks = 0;
             IsArchived = false;
+            CreatedDate = DateTime.UtcNow.ToString("yyyy-MM-dd");
 
             if (schedules?.Length > 0)
             {
@@ -98,17 +100,17 @@ namespace Cloud5mins.ShortenerTools.Core.Domain
             }
         }
 
-        public static ShortUrlEntity GetEntity(string longUrl, string endUrl, string title, Schedule[] schedules)
-        {
-            return new ShortUrlEntity
-            {
-                PartitionKey = endUrl.First().ToString(),
-                RowKey = endUrl,
-                Url = longUrl,
-                Title = title,
-                Schedules = schedules.ToList<Schedule>()
-            };
-        }
+        // public static ShortUrlEntity GetEntity(string longUrl, string endUrl, string title, Schedule[] schedules)
+        // {
+        //     return new ShortUrlEntity
+        //     {
+        //         PartitionKey = endUrl.First().ToString(),
+        //         RowKey = endUrl,
+        //         Url = longUrl,
+        //         Title = title,
+        //         Schedules = schedules.ToList<Schedule>()
+        //     };
+        // }
 
         private string GetActiveUrl()
         {

--- a/src/Core/Service/AzStrorageTablesService.cs
+++ b/src/Core/Service/AzStrorageTablesService.cs
@@ -65,6 +65,10 @@ public class AzStrorageTablesService(TableServiceClient client) : IAzStrorageTab
         {
             foreach (var item in emp.Values)
             {
+                if(item.CreatedDate == null)
+                {
+                    item.CreatedDate = item.Timestamp!.Value.UtcDateTime.ToString("yyyy-MM-dd") ?? string.Empty;
+                }
                 lstShortUrl.Add(item);
             }
         }

--- a/src/TinyBlazorAdmin/Components/Pages/UrlManager.razor
+++ b/src/TinyBlazorAdmin/Components/Pages/UrlManager.razor
@@ -59,6 +59,7 @@
                     <FluentButton OnClick="@(() => NavigateToStats(context.RowKey))" IconEnd="@(new Icons.Regular.Size16.ChartMultiple())" />
                 </FluentStack>
             </TemplateColumn>
+            <PropertyColumn Title="Created" Property="@(c => c!.CreatedDate)" Sortable="true" />
             <TemplateColumn Width="100px" Sortable="false">
                 <FluentButton OnClick="@(() => EditShortUrl(context))" IconEnd="@(new Icons.Regular.Size16.Edit())" Title="Edit" />
                 <FluentButton OnClick="@(async () => await ArchiveShortUrl(context))" IconEnd="@(new Icons.Regular.Size16.Archive())" Title="Archive" />


### PR DESCRIPTION
Adds the `CreatedDate` property to the `ShortUrlEntity` to track the creation date of short URLs.

Populates this property during entity creation and when retrieving entities from storage,
ensuring the creation date is consistently available.

Displays the `CreatedDate` in the UrlManager component for better visibility.
