### PR TITLE
add batch shortener function

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,8 +9,9 @@
 		"ghcr.io/devcontainers/features/dotnet:2": {},
 		"ghcr.io/devcontainers/features/github-cli:1": {},
 		"ghcr.io/azure/azure-dev/azd:0": {},
-		"ghcr.io/dotnet/aspire-devcontainer-feature/dotnetaspire:1": {}
-	}
+		"ghcr.io/dotnet/aspire-devcontainer-feature/dotnetaspire:1": {},
+		"ghcr.io/jlaundry/devcontainer-features/azure-functions-core-tools": {}
+	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
@@ -27,7 +28,13 @@
 	// "postCreateCommand": "dotnet restore",
 
 	// Configure tool-specific properties.
-	// "customizations": {},
+	"customizations": {
+			"vscode": {
+				"extensions": [
+					"ms-azuretools.vscode-azurefunctions"
+				]
+			}
+		}
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"

--- a/src/AppHost/Cloud5mins.ShortenerTools.AppHost.csproj
+++ b/src/AppHost/Cloud5mins.ShortenerTools.AppHost.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\Api\Cloud5mins.ShortenerTools.Api.csproj" />
     <ProjectReference Include="..\FunctionsLight\Cloud5mins.ShortenerTools.FunctionsLight.csproj" />
     <ProjectReference Include="..\TinyBlazorAdmin\Cloud5mins.ShortenerTools.TinyBlazorAdmin.csproj" />
+    <ProjectReference Include="..\BatchShortener\Cloud5mins.ShortenerTools.BatchShortener.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/AppHost/Program.cs
+++ b/src/AppHost/Program.cs
@@ -1,4 +1,5 @@
 
+using Aspire.Hosting;
 using Microsoft.Extensions.Hosting;
 
 var builder = DistributedApplication.CreateBuilder(args);
@@ -7,13 +8,12 @@ var customDomain = builder.AddParameter("CustomDomain");
 var defaultRedirectUrl = builder.AddParameter("DefaultRedirectUrl");
 
 var urlStorage = builder.AddAzureStorage("url-data");
+var strTables = urlStorage.AddTables("strTables");
 
 if (builder.Environment.IsDevelopment())
 {
     urlStorage.RunAsEmulator();
 }
-
-var strTables = urlStorage.AddTables("strTables");
 
 var azFuncLight = builder.AddAzureFunctionsProject<Projects.Cloud5mins_ShortenerTools_FunctionsLight>("azfunc-light")
 							.WithReference(strTables)
@@ -31,5 +31,8 @@ var manAPI = builder.AddProject<Projects.Cloud5mins_ShortenerTools_Api>("api")
 builder.AddProject<Projects.Cloud5mins_ShortenerTools_TinyBlazorAdmin>("admin")
 		.WithExternalHttpEndpoints()
 		.WithReference(manAPI);
+
+var batchShortenerFunction = builder.AddAzureFunctionsProject<Projects.Cloud5mins_ShortenerTools_BatchShortener>("batch-shortener")
+							  .WithReference(manAPI);
 
 builder.Build().Run();

--- a/src/AppHost/Properties/launchSettings.json
+++ b/src/AppHost/Properties/launchSettings.json
@@ -22,7 +22,9 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19258",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20204"
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20204",
+        "DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS": "true",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     }
   }

--- a/src/AppHost/appsettings.json
+++ b/src/AppHost/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning",
       "Aspire.Hosting.Dcp": "Warning"
     }
+  },
+  "Parameters": {
+    "CustomDomain": "n3rd.ly",
+    "DefaultRedirectUrl": "thenimblenerd.com"
   }
 }

--- a/src/AzUrlShortener.sln
+++ b/src/AzUrlShortener.sln
@@ -15,38 +15,102 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cloud5mins.ShortenerTools.A
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cloud5mins.ShortenerTools.TinyBlazorAdmin", "TinyBlazorAdmin\Cloud5mins.ShortenerTools.TinyBlazorAdmin.csproj", "{88EAB6E9-CD20-4A6B-86A0-38CACA87FC7E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cloud5mins.ShortenerTools.BatchShortener", "BatchShortener\Cloud5mins.ShortenerTools.BatchShortener.csproj", "{8B70C66C-F922-4CB0-BBE9-F3C310400F24}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "BatchShortener", "BatchShortener", "{152B325C-690A-6635-AC60-F2C724C37305}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{99DF620C-9FF5-4233-B556-E5E9E143AB60}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{99DF620C-9FF5-4233-B556-E5E9E143AB60}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{99DF620C-9FF5-4233-B556-E5E9E143AB60}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{99DF620C-9FF5-4233-B556-E5E9E143AB60}.Debug|x64.Build.0 = Debug|Any CPU
+		{99DF620C-9FF5-4233-B556-E5E9E143AB60}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{99DF620C-9FF5-4233-B556-E5E9E143AB60}.Debug|x86.Build.0 = Debug|Any CPU
 		{99DF620C-9FF5-4233-B556-E5E9E143AB60}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{99DF620C-9FF5-4233-B556-E5E9E143AB60}.Release|Any CPU.Build.0 = Release|Any CPU
+		{99DF620C-9FF5-4233-B556-E5E9E143AB60}.Release|x64.ActiveCfg = Release|Any CPU
+		{99DF620C-9FF5-4233-B556-E5E9E143AB60}.Release|x64.Build.0 = Release|Any CPU
+		{99DF620C-9FF5-4233-B556-E5E9E143AB60}.Release|x86.ActiveCfg = Release|Any CPU
+		{99DF620C-9FF5-4233-B556-E5E9E143AB60}.Release|x86.Build.0 = Release|Any CPU
 		{1C59956F-01A4-4F22-8B75-39CC48A8290C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1C59956F-01A4-4F22-8B75-39CC48A8290C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1C59956F-01A4-4F22-8B75-39CC48A8290C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1C59956F-01A4-4F22-8B75-39CC48A8290C}.Debug|x64.Build.0 = Debug|Any CPU
+		{1C59956F-01A4-4F22-8B75-39CC48A8290C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1C59956F-01A4-4F22-8B75-39CC48A8290C}.Debug|x86.Build.0 = Debug|Any CPU
 		{1C59956F-01A4-4F22-8B75-39CC48A8290C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1C59956F-01A4-4F22-8B75-39CC48A8290C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1C59956F-01A4-4F22-8B75-39CC48A8290C}.Release|x64.ActiveCfg = Release|Any CPU
+		{1C59956F-01A4-4F22-8B75-39CC48A8290C}.Release|x64.Build.0 = Release|Any CPU
+		{1C59956F-01A4-4F22-8B75-39CC48A8290C}.Release|x86.ActiveCfg = Release|Any CPU
+		{1C59956F-01A4-4F22-8B75-39CC48A8290C}.Release|x86.Build.0 = Release|Any CPU
 		{3DC7E590-FE84-4D0B-B989-9CD6B31B325A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3DC7E590-FE84-4D0B-B989-9CD6B31B325A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3DC7E590-FE84-4D0B-B989-9CD6B31B325A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3DC7E590-FE84-4D0B-B989-9CD6B31B325A}.Debug|x64.Build.0 = Debug|Any CPU
+		{3DC7E590-FE84-4D0B-B989-9CD6B31B325A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3DC7E590-FE84-4D0B-B989-9CD6B31B325A}.Debug|x86.Build.0 = Debug|Any CPU
 		{3DC7E590-FE84-4D0B-B989-9CD6B31B325A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3DC7E590-FE84-4D0B-B989-9CD6B31B325A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3DC7E590-FE84-4D0B-B989-9CD6B31B325A}.Release|x64.ActiveCfg = Release|Any CPU
+		{3DC7E590-FE84-4D0B-B989-9CD6B31B325A}.Release|x64.Build.0 = Release|Any CPU
+		{3DC7E590-FE84-4D0B-B989-9CD6B31B325A}.Release|x86.ActiveCfg = Release|Any CPU
+		{3DC7E590-FE84-4D0B-B989-9CD6B31B325A}.Release|x86.Build.0 = Release|Any CPU
 		{6567F739-8BCC-4B4B-8CCC-EEEB9B28465F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6567F739-8BCC-4B4B-8CCC-EEEB9B28465F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6567F739-8BCC-4B4B-8CCC-EEEB9B28465F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6567F739-8BCC-4B4B-8CCC-EEEB9B28465F}.Debug|x64.Build.0 = Debug|Any CPU
+		{6567F739-8BCC-4B4B-8CCC-EEEB9B28465F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6567F739-8BCC-4B4B-8CCC-EEEB9B28465F}.Debug|x86.Build.0 = Debug|Any CPU
 		{6567F739-8BCC-4B4B-8CCC-EEEB9B28465F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6567F739-8BCC-4B4B-8CCC-EEEB9B28465F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6567F739-8BCC-4B4B-8CCC-EEEB9B28465F}.Release|x64.ActiveCfg = Release|Any CPU
+		{6567F739-8BCC-4B4B-8CCC-EEEB9B28465F}.Release|x64.Build.0 = Release|Any CPU
+		{6567F739-8BCC-4B4B-8CCC-EEEB9B28465F}.Release|x86.ActiveCfg = Release|Any CPU
+		{6567F739-8BCC-4B4B-8CCC-EEEB9B28465F}.Release|x86.Build.0 = Release|Any CPU
 		{85C6D9A8-EB37-4FA3-9E83-7178825C9EA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{85C6D9A8-EB37-4FA3-9E83-7178825C9EA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{85C6D9A8-EB37-4FA3-9E83-7178825C9EA5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{85C6D9A8-EB37-4FA3-9E83-7178825C9EA5}.Debug|x64.Build.0 = Debug|Any CPU
+		{85C6D9A8-EB37-4FA3-9E83-7178825C9EA5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{85C6D9A8-EB37-4FA3-9E83-7178825C9EA5}.Debug|x86.Build.0 = Debug|Any CPU
 		{85C6D9A8-EB37-4FA3-9E83-7178825C9EA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{85C6D9A8-EB37-4FA3-9E83-7178825C9EA5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{85C6D9A8-EB37-4FA3-9E83-7178825C9EA5}.Release|x64.ActiveCfg = Release|Any CPU
+		{85C6D9A8-EB37-4FA3-9E83-7178825C9EA5}.Release|x64.Build.0 = Release|Any CPU
+		{85C6D9A8-EB37-4FA3-9E83-7178825C9EA5}.Release|x86.ActiveCfg = Release|Any CPU
+		{85C6D9A8-EB37-4FA3-9E83-7178825C9EA5}.Release|x86.Build.0 = Release|Any CPU
 		{88EAB6E9-CD20-4A6B-86A0-38CACA87FC7E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{88EAB6E9-CD20-4A6B-86A0-38CACA87FC7E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{88EAB6E9-CD20-4A6B-86A0-38CACA87FC7E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{88EAB6E9-CD20-4A6B-86A0-38CACA87FC7E}.Debug|x64.Build.0 = Debug|Any CPU
+		{88EAB6E9-CD20-4A6B-86A0-38CACA87FC7E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{88EAB6E9-CD20-4A6B-86A0-38CACA87FC7E}.Debug|x86.Build.0 = Debug|Any CPU
 		{88EAB6E9-CD20-4A6B-86A0-38CACA87FC7E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{88EAB6E9-CD20-4A6B-86A0-38CACA87FC7E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{88EAB6E9-CD20-4A6B-86A0-38CACA87FC7E}.Release|x64.ActiveCfg = Release|Any CPU
+		{88EAB6E9-CD20-4A6B-86A0-38CACA87FC7E}.Release|x64.Build.0 = Release|Any CPU
+		{88EAB6E9-CD20-4A6B-86A0-38CACA87FC7E}.Release|x86.ActiveCfg = Release|Any CPU
+		{88EAB6E9-CD20-4A6B-86A0-38CACA87FC7E}.Release|x86.Build.0 = Release|Any CPU
+		{8B70C66C-F922-4CB0-BBE9-F3C310400F24}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8B70C66C-F922-4CB0-BBE9-F3C310400F24}.Debug|x64.Build.0 = Debug|Any CPU
+		{8B70C66C-F922-4CB0-BBE9-F3C310400F24}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8B70C66C-F922-4CB0-BBE9-F3C310400F24}.Debug|x86.Build.0 = Debug|Any CPU
+		{8B70C66C-F922-4CB0-BBE9-F3C310400F24}.Release|x64.ActiveCfg = Release|Any CPU
+		{8B70C66C-F922-4CB0-BBE9-F3C310400F24}.Release|x64.Build.0 = Release|Any CPU
+		{8B70C66C-F922-4CB0-BBE9-F3C310400F24}.Release|x86.ActiveCfg = Release|Any CPU
+		{8B70C66C-F922-4CB0-BBE9-F3C310400F24}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/BatchShortener/Cloud5mins.ShortenerTools.BatchShortener.csproj
+++ b/src/BatchShortener/Cloud5mins.ShortenerTools.BatchShortener.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.2" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.40.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Core\Cloud5mins.ShortenerTools.Core.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="System.Threading.ExecutionContext" Alias="ExecutionContext" />
+  </ItemGroup>
+</Project>

--- a/src/BatchShortener/Functions/BatchShortener.cs
+++ b/src/BatchShortener/Functions/BatchShortener.cs
@@ -1,0 +1,107 @@
+using System.Net.Http.Json;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using Cloud5mins.ShortenerTools.BatchShortener.Models;
+using Cloud5mins.ShortenerTools.Core.Messages;
+
+namespace Cloud5mins.ShortenerTools.BatchShortener.Functions
+{
+    public class BatchShortener
+    {
+        private readonly ILogger _logger;
+        private readonly CosmosClient _cosmosClient;
+        private readonly IHttpClientFactory _httpClientFactory;
+
+        public BatchShortener(
+            ILogger<BatchShortener> logger,
+            CosmosClient cosmosClient,
+            IHttpClientFactory httpClientFactory)
+        {
+            _logger = logger;
+            _cosmosClient = cosmosClient;
+            _httpClientFactory = httpClientFactory;
+        }
+
+        [Function("BatchShortener")]
+        public async Task Run([TimerTrigger("%SCHEDULE%")] TimerInfo timer)
+        {
+            try
+            {
+                string dbName = Environment.GetEnvironmentVariable("CosmosDbName") ?? throw new InvalidOperationException("CosmosDbName environment variable is not set");
+                string containerName = Environment.GetEnvironmentVariable("CosmosDbContainerName") ?? throw new InvalidOperationException("CosmosDbContainerName environment variable is not set");
+                string apiUrl = Environment.GetEnvironmentVariable("ApiUrl") ?? throw new InvalidOperationException("ApiUrl environment variable is not set");
+
+                var container = _cosmosClient.GetContainer(dbName, containerName);
+
+                // Query for items that will/are published and are missing a Share_Url
+                var query = "SELECT * FROM c WHERE (c.Status = 'Ready to Publish' OR c.Status = 'Published') AND (NOT IS_DEFINED(c.Share_Url) OR c.Share_Url = '' OR c.Share_Url = null)";
+                var queryDefinition = new QueryDefinition(query);
+                using var resultsIterator = container.GetItemQueryIterator<CosmosDBEntry>(queryDefinition);
+
+                int updatedCount = 0;
+
+                while (resultsIterator.HasMoreResults)
+                {
+                    var response = await resultsIterator.ReadNextAsync();
+                    foreach (var item in response)
+                    {
+                        if (string.IsNullOrEmpty(item.Article_GUID))
+                        {
+                            _logger.LogWarning($"Item '{item.id}' has no Article_GUID to use for a shortened URL. Skipping.");
+                            continue;
+                        }
+
+                        var url = $"https://thenimblenerd.com/guid/{item.Article_GUID}";
+
+                        _logger.LogInformation($"Processing item '{item.id}' with the URL '{url}'");
+
+                        try
+                        {
+                            var httpClient = _httpClientFactory.CreateClient();
+
+                            var shortRequest = new ShortRequest
+                            {
+                                Url = url,
+                                Title = item.Article_Title ?? $"Auto-generated URL for {item.Article_GUID}"
+                            };
+                            var apiResponse = await httpClient.PostAsJsonAsync(apiUrl, shortRequest);
+                            apiResponse.EnsureSuccessStatusCode();
+
+                            // Get shortened URL
+                            var shortResponse = await apiResponse.Content.ReadFromJsonAsync<ShortResponse>();
+
+                            if (shortResponse != null && !string.IsNullOrEmpty(shortResponse.ShortUrl))
+                            {
+                                // Update the Cosmos DB Short_URL field only
+                                item.Share_Url = shortResponse.ShortUrl;
+                                var patchOperations = new List<PatchOperation>
+                                {
+                                    PatchOperation.Add("/Share_Url", item.Share_Url)
+                                };
+                                await container.PatchItemAsync<CosmosDBEntry>(
+                                    id: item.id,
+                                    partitionKey: new PartitionKey(item.id),
+                                    patchOperations: patchOperations
+                                );
+                                _logger.LogInformation($"Updated item '{item.id}' with Share_Url '{item.Share_Url}'");
+                                updatedCount++;
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex, $"Error updating item {item.id}: {ex.Message}");
+                        }
+                    }
+                }
+
+                _logger.LogInformation($"Created {updatedCount} shortened URLs");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"Error in BatchShortener function: {ex.Message}");
+            }
+        }
+    }
+}

--- a/src/BatchShortener/Models/CosmosDBEntry.cs
+++ b/src/BatchShortener/Models/CosmosDBEntry.cs
@@ -1,0 +1,10 @@
+namespace Cloud5mins.ShortenerTools.BatchShortener.Models
+{
+    public class CosmosDBEntry
+    {
+        public string id { get; set; } = string.Empty;
+        public string? Article_GUID { get; set; }
+        public string? Article_Title { get; set; }
+        public string? Share_Url { get; set; }
+    }
+}

--- a/src/BatchShortener/Program.cs
+++ b/src/BatchShortener/Program.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Azure.Cosmos;
+
+var host = new HostBuilder()
+    .ConfigureFunctionsWorkerDefaults()
+    .ConfigureServices(services =>
+    {
+        services.AddHttpClient();
+
+        // Add CosmosDB client as a singleton
+        services.AddSingleton(sp =>
+        {
+            string connectionString = Environment.GetEnvironmentVariable("CosmosDbConnectionString") ??
+                throw new InvalidOperationException("CosmosDbConnectionString environment variable is not set");
+
+            var cosmosClientOptions = new CosmosClientOptions
+            {
+                HttpClientFactory = () =>
+                {
+                    HttpMessageHandler httpMessageHandler = new HttpClientHandler()
+                    {
+                        // Enable for development purposes only
+                        // ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+                    };
+                    return new HttpClient(httpMessageHandler);
+                },
+                ConnectionMode = ConnectionMode.Gateway,
+                SerializerOptions = new CosmosSerializationOptions
+                {
+                    PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase,
+                }
+            };
+
+            return new CosmosClient(connectionString, cosmosClientOptions);
+        });
+    })
+    .Build();
+
+host.Run();

--- a/src/BatchShortener/host.json
+++ b/src/BatchShortener/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "logging": {
+    "logLevel": {
+      "System.Net.Http.HttpClient": "Trace",
+      "Microsoft.Extensions.Http": "Trace"
+    },
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This branch adds the BatchShortener function that runs on a timer. The function scans the cosmosdb for any entries that are missing a "Share_Url", it then calls the UrlShortner api and assigns the shortened link into "Share_Url". It will only create urls for articles that are ready to be published or already published.

To run successfully it needs these env variables:
- CosmosDbConnectionString
- CosmosDbName
- CosmosDbContainerName
- ApiUrl (the UrlShortener api, it should end in /UrlCreate)
- SCHEDULE (the schedule the trigger runs on)